### PR TITLE
Fix

### DIFF
--- a/mod/localization/miscellaneous.string_table.xml
+++ b/mod/localization/miscellaneous.string_table.xml
@@ -284,7 +284,7 @@
     <entry id="effect_tooltip_heal_format"><![CDATA[{colour_start|healhp}Cura{colour_end} %d PF]]></entry>
     <entry id="effect_tooltip_heal_percent_format"><![CDATA[{colour_start|healhp}Cura{colour_end} %d%% dei PF massimi]]></entry>
     <entry id="effect_tooltip_hp_heal_dot_format"><![CDATA[{colour_start|healhp}Cura{colour_end} %d punti per turno per %d turni]]></entry>
-    <entry id="effect_tooltip_kill_enemy_type"><![CDATA[Rimuovi ogni %s]]></entry>
+    <entry id="effect_tooltip_kill_enemy_type"><![CDATA[Rimuovi tutti i cadaveri dei nemici]]></entry>
     <entry id="effect_tooltip_move_backward"><![CDATA[{colour_start|knockback}Spingi{colour_end} %d]]></entry>
     <entry id="effect_tooltip_move_forward"><![CDATA[{colour_start|move}Tira{colour_end} %d]]></entry>
     <entry id="effect_tooltip_party"><![CDATA[Tutti gli Eroi:]]></entry>


### PR DESCRIPTION
Ho preso spunto da dlc arena. Loro hanno ovviato nel dlc a quell'errore scrivendo per intero in ogni lingua togliento la variabile %s tanto a quella id corrisponde solo la parola cadavere (singolare e plurale) così facendo è in italiano perfetto e in linea con il dlc